### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ playlist main {
 play main;
 ```
 
-### Grammer
+### Grammar
 
 Top-level:
 


### PR DESCRIPTION
"Grammar" is the correct usage here. See https://www.grammar.com/grammer_vs._grammar